### PR TITLE
Fix cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.20)
 project(CMD_LINE_PARSER)
 
-enable_testing()
-
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
-
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME}
+add_library(CMD_LINE_PARSER INTERFACE)
+target_include_directories(CMD_LINE_PARSER
         INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    enable_testing()
+    add_subdirectory(src)
+endif()


### PR DESCRIPTION
- Using `PROJECT_NAME` was misleading because the `add_subdirectory` call below that changed the project name.
- Only add testing and additional targets if this is the main project. Dependencies using this project do not need access to `test_parse.cpp`